### PR TITLE
Switch to .NET 4.0

### DIFF
--- a/System.Configuration.Abstractions.Test.Unit/System.Configuration.Abstractions.Test.Unit.csproj
+++ b/System.Configuration.Abstractions.Test.Unit/System.Configuration.Abstractions.Test.Unit.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Configuration.Abstractions.Test.Unit</RootNamespace>
     <AssemblyName>System.Configuration.Abstractions.Test.Unit</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/System.Configuration.Abstractions/AppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/AppSettingsExtended.cs
@@ -174,14 +174,14 @@ namespace System.Configuration.Abstractions
                 {
                     var value = AppSetting(matchedKey.First());
                     var typed = Convert.ChangeType(value, propertyInfo.PropertyType);
-                    propertyInfo.SetValue(instance, typed);
+                    propertyInfo.SetValue(instance, typed, null);
                 }
 
                 if (!propertyInfo.PropertyType.IsPrimitive 
                     && propertyInfo.PropertyType.GetConstructor(Type.EmptyTypes) != null)
                 {
                     var subType = Activator.CreateInstance(propertyInfo.PropertyType);
-                    propertyInfo.SetValue(instance, subType);
+                    propertyInfo.SetValue(instance, subType, null);
                     RecursivelyMapProperties(propertyInfo.PropertyType, subType, lookupName);
                 }
             }

--- a/System.Configuration.Abstractions/ConfigurationManager.cs
+++ b/System.Configuration.Abstractions/ConfigurationManager.cs
@@ -81,11 +81,6 @@ namespace System.Configuration.Abstractions
             return System.Configuration.ConfigurationManager.OpenMappedExeConfiguration(fileMap, userLevel);
         }
 
-        public Configuration OpenMappedExeConfiguration(ExeConfigurationFileMap fileMap, ConfigurationUserLevel userLevel, bool preLoad)
-        {
-            return System.Configuration.ConfigurationManager.OpenMappedExeConfiguration(fileMap, userLevel, preLoad);
-        }
-
         public Configuration OpenMappedExeConfiguration(ExeConfigurationFileMap fileMap)
         {
             return System.Configuration.ConfigurationManager.OpenMappedMachineConfiguration(fileMap);

--- a/System.Configuration.Abstractions/IConfigurationManager.cs
+++ b/System.Configuration.Abstractions/IConfigurationManager.cs
@@ -10,7 +10,6 @@
         Configuration OpenExeConfiguration(ConfigurationUserLevel userLevel);
         Configuration OpenMachineConfiguration();
         Configuration OpenMappedExeConfiguration(ExeConfigurationFileMap fileMap, ConfigurationUserLevel userLevel);
-        Configuration OpenMappedExeConfiguration(ExeConfigurationFileMap fileMap, ConfigurationUserLevel userLevel, bool preLoad);
         Configuration OpenMappedExeConfiguration(ExeConfigurationFileMap fileMap);
     }
 }

--- a/System.Configuration.Abstractions/System.Configuration.Abstractions.csproj
+++ b/System.Configuration.Abstractions/System.Configuration.Abstractions.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Configuration.Abstractions</RootNamespace>
     <AssemblyName>System.Configuration.Abstractions</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
We are still under .NET 4.0 for most of our project.

I ported this excellent library (thanks !) to .NET 4.0.

One method had to be sacrificied but I am not sure it is very used.

If you agree, would you consider merging it and publishing a new nuget version.

Thanks,