### PR TITLE
surround key name with single quotes for readability

### DIFF
--- a/System.Configuration.Abstractions/AppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/AppSettingsExtended.cs
@@ -40,8 +40,8 @@ namespace System.Configuration.Abstractions
                     return whenKeyNotFoundInsteadOfThrowingDefaultException();
                 }
 
-                throw new ConfigurationErrorsException("Calling code requested setting named " + key +
-                                                       " but it was not in the config file.");
+                throw new ConfigurationErrorsException("Calling code requested setting named '" + key +
+                                                       "' but it was not in the config file.");
             }
 
             rawSetting = Intercept(key, rawSetting);


### PR DESCRIPTION
This is a super, super, super-duper minor change that helps with readability. I find that user input fields are sometimes hard to read and a message like:

```"Calling code requested setting named  but it was not in the config file.``` (if the appSettings key was blank)

or

```Calling code requested setting named key but it was not in the config file.``` (in the case of a poorly named appSettings key)

Single quotes help in these cases.