### PR TITLE
Added an alternative non-throw ex version of getting AppSetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Examples:
 
 ## Generic typed helper methods for retrieving typed config values
 
-The `IAppSettingsExtended` interface, which our `AppSettingsExtended` class implements, contains two new methods:
+The `IAppSettingsExtended` interface, which our `AppSettingsExtended` class implements, contains three new methods:
 
 * `string AppSetting(string key, Func<string> whenKeyNotFoundInsteadOfThrowingDefaultException = null);`
 * `T AppSetting<T>(string key, Func<T> whenKeyNotFoundInsteadOfThrowingDefaultException = null);`
+* `T AppSettingSilent<T>(string key, Func<T> insteadOfThrowingDefaultException = null);`
 
 These strongly typed "AppSetting" helpers, will convert any primitive types that `Convert.ChangeType` supports. The most obvious use case being int / bool / float / int? / bool? from their string representations - keeping alot of noisy conversions out of your code. You can also provide an optional Func<T> which will get invoked if the key you're requesting is not found - otherwise, we'll throw an exception.
 
@@ -103,6 +104,20 @@ The following usage examples illustrate how to use these helpers:
         someBool = true; // Default
     }
 
+	bool? someBool;
+	try
+	{
+		var settingThatIsABool = System.Configuration.ConfigurationManager.AppSettings["otherKey"];
+		if (bool.TryParse(settingThatIsAnInteger, out someBool))
+		{
+			someBool = true; // Default
+		}
+	}
+	catch
+	{
+		someBool = true;
+	}
+	
     // After ********************************
     
     var withADefault = ConfigurationManager.Instance.AppSettings.AppSetting("key", () => 123);
@@ -114,6 +129,16 @@ The following usage examples illustrate how to use these helpers:
     var customNotFoundHandler = ConfigurationManager.Instance.AppSettings.AppSetting<bool?>("otherKey", () =>
     {
         throw new MyCustomException();
+    });
+	
+	var defaultValue = true;
+	var silentHandler = configurationManagerExtended.AppSettingSilent<bool>("otherKey", () =>
+    {
+		// Log Warning
+		// ...
+		
+		// Return Default
+        return defaultValue;
     });
 ```    
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Examples:
 
 ## Generic typed helper methods for retrieving typed config values
 
-The `IAppSettingsExtended` interface, which our `AppSettingsExtended` class implements, contains three new methods:
+The `IAppSettingsExtended` interface, which our `AppSettingsExtended` class implements, contains four new methods:
 
 * `string AppSetting(string key, Func<string> whenKeyNotFoundInsteadOfThrowingDefaultException = null);`
 * `T AppSetting<T>(string key, Func<T> whenKeyNotFoundInsteadOfThrowingDefaultException = null);`
+* `T AppSettingConvert<T>(string key, Func<T> whenConversionFailsInsteadOfThrowingDefaultException = null);`
 * `T AppSettingSilent<T>(string key, Func<T> insteadOfThrowingDefaultException = null);`
 
 These strongly typed "AppSetting" helpers, will convert any primitive types that `Convert.ChangeType` supports. The most obvious use case being int / bool / float / int? / bool? from their string representations - keeping alot of noisy conversions out of your code. You can also provide an optional Func<T> which will get invoked if the key you're requesting is not found - otherwise, we'll throw an exception.
@@ -125,10 +126,24 @@ The following usage examples illustrate how to use these helpers:
     
     var worksWithAllPrimatives = ConfigurationManager.Instance.AppSettings.AppSetting<bool>("otherKey");
     var worksWithNullables = ConfigurationManager.Instance.AppSettings.AppSetting<bool?>("otherKey");
+
+    var customNotFoundHandler = ConfigurationManager.Instance.AppSettings.AppSetting<bool?>("otherKey", () =>
+    {
+        throw new MyCustomMissingKeyException();
+    });
     
     var customNotFoundHandler = ConfigurationManager.Instance.AppSettings.AppSetting<bool?>("otherKey", () =>
     {
-        throw new MyCustomException();
+        throw new MyCustomMissingKeyException();
+    },
+	() =>
+    {
+        throw new MyCustomConversionException();
+    });
+
+    var customNotFoundHandler = configurationManagerExtended.AppSettingConvert<bool?>("otherKey", () =>
+    {
+        throw new MyCustomConversionException();
     });
 	
 	var defaultValue = true;

--- a/System.Configuration.Abstractions.Test.Unit/AppSettingsExtendedTests.cs
+++ b/System.Configuration.Abstractions.Test.Unit/AppSettingsExtendedTests.cs
@@ -118,22 +118,79 @@ namespace System.Configuration.Abstractions.Test.Unit
 
         [TestCase("NotSoTrue", true)]
         [TestCase("NotSoTrue", false)]
-        public void SettingSilently_WhenExceptionRaisedAndActionSupplied_PerformsAction(string boolValue, bool expectationAndDefault)
+        public void Setting_WhenExceptionRaisedAndBothActionsSupplied_PerformsAction(string boolValue, bool expectationAndDefault)
         {
             _underlyingConfiguration.Add("key-that-fails-cast", boolValue);
 
-            var val = _wrapper.AppSettingSilent("key-that-fails-cast", () => expectationAndDefault);
+            Func<bool> insteadOfThrowingConversionException = () => expectationAndDefault;
+            var insteadOfThrowingMissingKeyException = insteadOfThrowingConversionException;
+
+            var val = _wrapper.AppSetting("key-that-fails-cast", insteadOfThrowingMissingKeyException, insteadOfThrowingConversionException);
 
             Assert.That(val, Is.EqualTo(expectationAndDefault));
         }
         
+        [TestCase("NotSoTrue", true)]
+        [TestCase("NotSoTrue", false)]
+        public void Setting_WhenExceptionRaisedAndConversionActionSupplied_PerformsAction(string boolValue, bool expectationAndDefault)
+        {
+            _underlyingConfiguration.Add("key-that-fails-cast", boolValue);
+
+            Func<bool> insteadOfThrowingConversionException = () => expectationAndDefault;
+
+            var val = _wrapper.AppSettingConvert("key-that-fails-cast", insteadOfThrowingConversionException);
+
+            Assert.That(val, Is.EqualTo(expectationAndDefault));
+        }        
+        
+        [TestCase("NotSoTrue", true)]
+        [TestCase("NotSoTrue", false)]
+        public void SettingSilent_WhenConversionFailsAndAnyExceptionActionSupplied_PerformsAction(string boolValue, bool expectationAndDefault)
+        {
+            _underlyingConfiguration.Add("key-that-fails-cast", boolValue);
+
+            Func<bool> insteadOfThrowingException = () => expectationAndDefault;
+
+            var val = _wrapper.AppSettingSilent("key-that-fails-cast", insteadOfThrowingException);
+
+            Assert.That(val, Is.EqualTo(expectationAndDefault));
+        }
+        
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SettingSilent_WhenMissingKeyFailsAndAnyExceptionActionSupplied_PerformsAction(bool expectedOutcome)
+        {
+            _underlyingConfiguration.Remove("missing-key");
+
+            Func<bool> insteadOfThrowingException = () => expectedOutcome;
+
+            var val = _wrapper.AppSettingSilent("missing-key", insteadOfThrowingException);
+
+            Assert.That(val, Is.EqualTo(expectedOutcome));
+        }
 
         [Test]
-        public void SettingSilently_WhenExceptionRaisedAndActionNotSupplied_PerformsAction()
+        public void SettingConvert_WhenExceptionRaisedAndActionNotSupplied_PerformsAction()
+        {
+            _underlyingConfiguration.Add("key-that-fails-cast", "NotSoTrue");
+
+            Assert.Throws<FormatException>(() => _wrapper.AppSettingConvert<bool>("key-that-fails-cast"));
+        }
+        
+        [Test]
+        public void SettingSilent_WhenExceptionRaisedAndActionNotSupplied_PerformsAction()
         {
             _underlyingConfiguration.Add("key-that-fails-cast", "NotSoTrue");
 
             Assert.Throws<FormatException>(() => _wrapper.AppSettingSilent<bool>("key-that-fails-cast"));
+        }
+        
+        [Test]
+        public void Setting_WhenExceptionRaisedAndActionNotSupplied_PerformsAction()
+        {
+            _underlyingConfiguration.Add("key-that-fails-cast", "NotSoTrue");
+
+            Assert.Throws<FormatException>(() => _wrapper.AppSetting<bool>("key-that-fails-cast"));
         }
 
         [Test]

--- a/System.Configuration.Abstractions.Test.Unit/AppSettingsExtendedTests.cs
+++ b/System.Configuration.Abstractions.Test.Unit/AppSettingsExtendedTests.cs
@@ -116,6 +116,26 @@ namespace System.Configuration.Abstractions.Test.Unit
             Assert.That(val, Is.EqualTo("default thing"));
         }
 
+        [TestCase("NotSoTrue", true)]
+        [TestCase("NotSoTrue", false)]
+        public void SettingSilently_WhenExceptionRaisedAndActionSupplied_PerformsAction(string boolValue, bool expectationAndDefault)
+        {
+            _underlyingConfiguration.Add("key-that-fails-cast", boolValue);
+
+            var val = _wrapper.AppSettingSilent("key-that-fails-cast", () => expectationAndDefault);
+
+            Assert.That(val, Is.EqualTo(expectationAndDefault));
+        }
+        
+
+        [Test]
+        public void SettingSilently_WhenExceptionRaisedAndActionNotSupplied_PerformsAction()
+        {
+            _underlyingConfiguration.Add("key-that-fails-cast", "NotSoTrue");
+
+            Assert.Throws<FormatException>(() => _wrapper.AppSettingSilent<bool>("key-that-fails-cast"));
+        }
+
         [Test]
         public void Setting_WhenSettingDoesNotExistAndActionSuppliedReturnsATypedThing_ReturnsTypedThing()
         {

--- a/System.Configuration.Abstractions/AppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/AppSettingsExtended.cs
@@ -31,7 +31,7 @@ namespace System.Configuration.Abstractions
             {
                 appSetting = AppSetting(key, insteadOfThrowingDefaultException);
             }
-            catch (Exception)
+            catch
             {
                 if (insteadOfThrowingDefaultException != null)
                 {

--- a/System.Configuration.Abstractions/AppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/AppSettingsExtended.cs
@@ -23,7 +23,27 @@ namespace System.Configuration.Abstractions
             RecursivelyMapProperties(typeof(TSettingsDto), instance);
             return instance;
         }
-        
+
+        public T AppSettingSilent<T>(string key, Func<T> insteadOfThrowingDefaultException = null)
+        {
+            T appSetting;
+            try
+            {
+                appSetting = AppSetting(key, insteadOfThrowingDefaultException);
+            }
+            catch (Exception)
+            {
+                if (insteadOfThrowingDefaultException != null)
+                {
+                    return insteadOfThrowingDefaultException();
+                }
+
+                throw;
+            }
+
+            return appSetting;
+        }
+
         public string AppSetting(string key, Func<string> whenKeyNotFoundInsteadOfThrowingDefaultException = null)
         {
             return AppSetting<string>(key, whenKeyNotFoundInsteadOfThrowingDefaultException);

--- a/System.Configuration.Abstractions/ConfigurationManager.cs
+++ b/System.Configuration.Abstractions/ConfigurationManager.cs
@@ -35,8 +35,8 @@ namespace System.Configuration.Abstractions
         {
         }
 
-        public ConfigurationManager(NameValueCollection appSettingss)
-            : this(appSettingss, System.Configuration.ConfigurationManager.ConnectionStrings)
+        public ConfigurationManager(NameValueCollection appSettings)
+            : this(appSettings, System.Configuration.ConfigurationManager.ConnectionStrings)
         {
         }
 

--- a/System.Configuration.Abstractions/IAppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/IAppSettingsExtended.cs
@@ -5,7 +5,7 @@ namespace System.Configuration.Abstractions
     public interface IAppSettingsExtended
     {
         NameValueCollection Raw { get; }
-
+        T AppSettingSilent<T>(string key, Func<T> insteadOfThrowingDefaultException = null);
         string AppSetting(string key, Func<string> whenKeyNotFoundInsteadOfThrowingDefaultException = null);
         T AppSetting<T>(string key, Func<T> whenKeyNotFoundInsteadOfThrowingDefaultException = null);
         TSettingsDto Map<TSettingsDto>() where TSettingsDto : class, new();

--- a/System.Configuration.Abstractions/IAppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/IAppSettingsExtended.cs
@@ -6,8 +6,9 @@ namespace System.Configuration.Abstractions
     {
         NameValueCollection Raw { get; }
         T AppSettingSilent<T>(string key, Func<T> insteadOfThrowingDefaultException = null);
+        T AppSettingConvert<T>(string key, Func<T> whenConversionFailsInsteadOfThrowingDefaultException = null);
         string AppSetting(string key, Func<string> whenKeyNotFoundInsteadOfThrowingDefaultException = null);
-        T AppSetting<T>(string key, Func<T> whenKeyNotFoundInsteadOfThrowingDefaultException = null);
+        T AppSetting<T>(string key, Func<T> whenKeyNotFoundInsteadOfThrowingDefaultException = null, Func<T> whenConversionFailsInsteadOfThrowingDefaultException = null);
         TSettingsDto Map<TSettingsDto>() where TSettingsDto : class, new();
     }
 }


### PR DESCRIPTION
Was finding that I was try/catching in the case of cast failures so added silent option to where you supply a func<> to run in case of an exception either from convert() or missing key.