### PR TITLE
Helper - UriConverter

### DIFF
--- a/System.Configuration.Abstractions.Test.Unit/AppSettingsExtendedTests.cs
+++ b/System.Configuration.Abstractions.Test.Unit/AppSettingsExtendedTests.cs
@@ -248,6 +248,18 @@ namespace System.Configuration.Abstractions.Test.Unit
 
             Assert.That(val, Is.EqualTo(1.0m));
         }
+        
+        [Test]
+        public void Setting_RequestAUri_ConvertsSettingValue()
+        {
+            _underlyingConfiguration.Add("uriKey", "http://www.jazz.town.com");
+
+            var val = _wrapper.AppSetting<Uri>("uriKey");
+
+            var expected = new Uri("http://www.jazz.town.com");
+
+            Assert.That(val, Is.EqualTo(expected));
+        }
 
         [Test]
         public void Setting_RequestAnInvalidDouble_ThrowsUnderlyingException()
@@ -263,6 +275,14 @@ namespace System.Configuration.Abstractions.Test.Unit
             _underlyingConfiguration.Add("double", "NO DOUBLE HERE");
 
             Assert.Throws<FormatException>(() => _wrapper.AppSetting("double", () => 1.0));
+        }
+        
+        [Test]
+        public void Setting_RequestAnInvalidUriWithDefault_ThrowsUnderlyingException()
+        {
+            _underlyingConfiguration.Add("badUriKey", "bad.uri.com");
+
+            Assert.Throws<UriFormatException>(() => _wrapper.AppSetting("badUriKey", () => new Uri("http://www.jazz.town.com")));
         }
 
         [Test]

--- a/System.Configuration.Abstractions/AppSettingsExtended.cs
+++ b/System.Configuration.Abstractions/AppSettingsExtended.cs
@@ -57,8 +57,13 @@ namespace System.Configuration.Abstractions
             try 
             {
                 rawSetting = Intercept(key, rawSetting);
+                
+                if (IsUriType(typeof(T)))
+                    return ConvertToUri<T>(rawSetting);
+                
+                var convertedSetting = (T) Convert.ChangeType(rawSetting, typeof (T));
 
-                return (T) Convert.ChangeType(rawSetting, typeof (T));
+                return convertedSetting;
             }
             catch
             {
@@ -69,6 +74,20 @@ namespace System.Configuration.Abstractions
 
                 throw;
             }
+        }
+        
+        private static T ConvertToUri<T>(string rawSetting)
+        {
+            var uri = (T) (object) (new Uri(rawSetting));
+
+            return uri;
+        }
+
+        private static bool IsUriType(Type t)
+        {
+            var isUri = t == typeof(Uri);
+
+            return isUri;
         }
 
         private string Intercept(string key, string rawSetting)


### PR DESCRIPTION
Due to Uri being commonly store in configs I have added a check/converter to allow Uri to be handled like primitives.

In the future we could maybe expose some sort of TypeConverter collection and check items that initially throw conversion exception against this list of converters before we throw the exception.