### PR TITLE
IConnectionStrings is enumerable and can be used in a foreach loop

### DIFF
--- a/System.Configuration.Abstractions.Test.Unit/ConnectionStringsExtendedTests.cs
+++ b/System.Configuration.Abstractions.Test.Unit/ConnectionStringsExtendedTests.cs
@@ -13,7 +13,7 @@ namespace System.Configuration.Abstractions.Test.Unit
         [SetUp]
         public void SetUp()
         {
-            _fakeConfig = new ConnectionStringSettingsCollection {new ConnectionStringSettings("key-here", "junk")};
+            _fakeConfig = new ConnectionStringSettingsCollection { new ConnectionStringSettings("key-here", "junk") };
             _wrapper = new ConnectionStringsExtended(_fakeConfig, new AppSettingsExtended(new NameValueCollection()));
         }
 
@@ -29,7 +29,7 @@ namespace System.Configuration.Abstractions.Test.Unit
         public void Indexer_WhenSettingExists_RunsAnyRegisteredInterceptorsAndReturnsSetting()
         {
             var wrapper = new ConnectionStringsExtended(_fakeConfig, new AppSettingsExtended(new NameValueCollection()),
-                    new List<IConnectionStringInterceptor> {new TestConnectionStringInterceptor("return this")});
+                    new List<IConnectionStringInterceptor> { new TestConnectionStringInterceptor("return this") });
 
             var val = wrapper["key-here"];
 
@@ -54,30 +54,39 @@ namespace System.Configuration.Abstractions.Test.Unit
 
             Assert.That(val, Is.Null);
         }
-    }
 
-    public class NullConnectionStringInterceptor : IConnectionStringInterceptor
-    {
-        public ConnectionStringSettings OnConnectionStringRetrieve(IAppSettings appSettings, IConnectionStrings connectionStrings,
-            ConnectionStringSettings originalValue)
+        [Test]
+        public void ConnectionStrings_Are_Enumerable()
         {
-            return null;
-        }
-    }
+            _wrapper.Add(new ConnectionStringSettings("UK_Conn", "UK_DB_ConnString"));
 
-    public class TestConnectionStringInterceptor : IConnectionStringInterceptor
-    {
-        private readonly string _returnThis;
-
-        public TestConnectionStringInterceptor(string returnThis)
-        {
-            _returnThis = returnThis;
+            Assert.That(_wrapper.GetEnumerator(), Is.Not.Null);
+            Assert.That(_wrapper.Raw.Count, Is.EqualTo(2));
         }
 
-        public ConnectionStringSettings OnConnectionStringRetrieve(IAppSettings appSettings, IConnectionStrings connectionStrings,
-            ConnectionStringSettings originalValue)
+        public class NullConnectionStringInterceptor : IConnectionStringInterceptor
         {
-            return new ConnectionStringSettings(originalValue.Name, _returnThis, originalValue.ProviderName);
+            public ConnectionStringSettings OnConnectionStringRetrieve(IAppSettings appSettings, IConnectionStrings connectionStrings,
+                ConnectionStringSettings originalValue)
+            {
+                return null;
+            }
+        }
+
+        public class TestConnectionStringInterceptor : IConnectionStringInterceptor
+        {
+            private readonly string _returnThis;
+
+            public TestConnectionStringInterceptor(string returnThis)
+            {
+                _returnThis = returnThis;
+            }
+
+            public ConnectionStringSettings OnConnectionStringRetrieve(IAppSettings appSettings, IConnectionStrings connectionStrings,
+                ConnectionStringSettings originalValue)
+            {
+                return new ConnectionStringSettings(originalValue.Name, _returnThis, originalValue.ProviderName);
+            }
         }
     }
 }

--- a/System.Configuration.Abstractions.Test.Unit/System.Configuration.Abstractions.Test.Unit.csproj
+++ b/System.Configuration.Abstractions.Test.Unit/System.Configuration.Abstractions.Test.Unit.csproj
@@ -60,6 +60,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/System.Configuration.Abstractions/ConnectionStringsExtended.cs
+++ b/System.Configuration.Abstractions/ConnectionStringsExtended.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +7,7 @@ namespace System.Configuration.Abstractions
     public class ConnectionStringsExtended : IConnectionStrings
     {
         public ConnectionStringSettingsCollection Raw { get; private set; }
-       
+
         private readonly IEnumerable<IConnectionStringInterceptor> _interceptors;
         private readonly IAppSettings _appSettings;
 
@@ -62,6 +63,19 @@ namespace System.Configuration.Abstractions
             rawSetting = _interceptors.Aggregate(rawSetting,
                 (current, interceptor) => interceptor.OnConnectionStringRetrieve(_appSettings, this, current));
             return rawSetting;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.Raw.GetEnumerator();
+        }
+
+        public IEnumerator<ConnectionStringSettings> GetEnumerator()
+        {
+            for (int pos = 0; pos < Raw.Count; pos++)
+            {
+                yield return Raw[pos];
+            }
         }
     }
 }

--- a/System.Configuration.Abstractions/ConnectionStringsExtended.cs
+++ b/System.Configuration.Abstractions/ConnectionStringsExtended.cs
@@ -74,7 +74,7 @@ namespace System.Configuration.Abstractions
         {
             for (int pos = 0; pos < Raw.Count; pos++)
             {
-                yield return Raw[pos];
+                yield return Intercept(Raw[pos]);
             }
         }
     }

--- a/System.Configuration.Abstractions/IConnectionStrings.cs
+++ b/System.Configuration.Abstractions/IConnectionStrings.cs
@@ -1,6 +1,8 @@
-﻿namespace System.Configuration.Abstractions
+﻿using System.Collections.Generic;
+
+namespace System.Configuration.Abstractions
 {
-    public interface IConnectionStrings
+    public interface IConnectionStrings : IEnumerable<ConnectionStringSettings>
     {
         ConnectionStringSettings this[string name] { get; }
         ConnectionStringSettings this[int index] { get; }


### PR DESCRIPTION
## Feature - Enumerable IConnectionStrings

### What is it?

* Found a need in a personal project to be able to collect/pick up on defined connectionstrings in the configuration without knowing the fully qualified identifier for the connection string key. Example is there could be a differing number of connection strings pointing to country databases but it is not known whilst coding which and how many databases the application will connect to.

### Additonal Comments?

This is a great project, thank you for sharing. Being able to use configuration values without referencing the original baked in ConfigurationManager and be able to unit test without writing custom wrapper interfaces is a big relief across existing and new projects.