### PR TITLE
Added .Net Standard version of the library

### DIFF
--- a/System.Configuration.Abstractions.NetStandard/System.Configuration.Abstractions.NetStandard.csproj
+++ b/System.Configuration.Abstractions.NetStandard/System.Configuration.Abstractions.NetStandard.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\System.Configuration.Abstractions\*.cs">
+      <Link>%(FileName)</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\System.Configuration.Abstractions\Interceptors\*.cs">
+      <Link>%(FileName)</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\System.Configuration.Abstractions\TypeConverters\*.cs">
+      <Link>%(FileName)</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+  </ItemGroup>
+</Project>

--- a/System.Configuration.Abstractions.NetStandard/System.Configuration.Abstractions.NetStandard.csproj
+++ b/System.Configuration.Abstractions.NetStandard/System.Configuration.Abstractions.NetStandard.csproj
@@ -1,6 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <PackageId>System.Configuration.Abstractions</PackageId>
+        <Authors>System.Configuration.Abstractions</Authors>
+        <Company>David Whitney / Electric Head Software LTD</Company>
+        <Product>David Whitney</Product>
+        <Description>Interfaced wrappers around System Configuration ConfigurationManager with support for extensibility points and strongly typed helpers.</Description>
+        <Copyright>Copyright ©David Whitney  2013</Copyright>
+        <PackageProjectUrl>https://github.com/davidwhitney/System.Configuration.Abstractions</PackageProjectUrl>
+        <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+        <Version>2.0.0</Version>
+        <PackageTags>ConfigurationManager Abstraction System.Configuration</PackageTags>
     </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\System.Configuration.Abstractions\*.cs">

--- a/System.Configuration.Abstractions.sln
+++ b/System.Configuration.Abstractions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Configuration.Abstractions", "System.Configuration.Abstractions\System.Configuration.Abstractions.csproj", "{7B47571C-57D0-4B0B-AF9E-1BBB307CAE69}"
 EndProject
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{538A87
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Configuration.Abstractions.Net40", "System.Configuration.Abstractions.Net40\System.Configuration.Abstractions.Net40.csproj", "{63F46237-8D4E-4D87-AAF1-6DD6BC869409}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Configuration.Abstractions.NetStandard", "System.Configuration.Abstractions.NetStandard\System.Configuration.Abstractions.NetStandard.csproj", "{14A6F22E-52C9-4E33-96F3-1AC5D6475CE0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,8 +36,15 @@ Global
 		{63F46237-8D4E-4D87-AAF1-6DD6BC869409}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63F46237-8D4E-4D87-AAF1-6DD6BC869409}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63F46237-8D4E-4D87-AAF1-6DD6BC869409}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14A6F22E-52C9-4E33-96F3-1AC5D6475CE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14A6F22E-52C9-4E33-96F3-1AC5D6475CE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14A6F22E-52C9-4E33-96F3-1AC5D6475CE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14A6F22E-52C9-4E33-96F3-1AC5D6475CE0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8E80D293-F00B-485F-BA26-ACE05BD55D2D}
 	EndGlobalSection
 EndGlobal

--- a/System.Configuration.Abstractions/System.Configuration.Abstractions.nuspec
+++ b/System.Configuration.Abstractions/System.Configuration.Abstractions.nuspec
@@ -17,10 +17,18 @@
 		<frameworkAssembly assemblyName="System.Configuration" targetFramework="net40" />
     </frameworkAssemblies>
 	<releaseNotes>Added support for .NET40 - one of the .NET45 only interfaces is unavailable in the .NET40 port.</releaseNotes>
+		<dependencies>
+		<group targetFramework="netstandard2.0">
+			<dependency id="NETStandard.Library" version ="2.0.0" />
+			<dependency id="System.Configuration.ConfigurationManager" version="4.4.1" />
+		</group>
+	</dependencies>
   </metadata>
 	<files>	  
 	  <file src="..\System.Configuration.Abstractions.Net40\bin\Release\*.dll" target="lib\net40" /> 
 	  <file src="..\System.Configuration.Abstractions.Net40\bin\Release\*.pdb" target="lib\net40" /> 
+	  <file src="..\System.Configuration.Abstractions.NetStandard\bin\Release\netstandard2.0\*.dll" target="lib\netstandard2.0" /> 
+	  <file src="..\System.Configuration.Abstractions.NetStandard\bin\Release\netstandard2.0\*.pdb" target="lib\netstandard2.0" /> 
 	  <file src="bin\Release\*.pdb" target="lib\net45" /> 
-	</files> 
+	</files>
 </package>

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe /m:8 /p:Configuration=Release "System.Configuration.Abstractions.sln"
+"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" /m:8 /p:Configuration=Release "System.Configuration.Abstractions.sln"


### PR DESCRIPTION
There is now a new project within the solution that creates a .Net Standard version of the library. This is a .Net Standard 2.0 library as the `System.Configuration` dependencies are only available for .Net Core 2.0.

I've also had to change `build.bat` to use the VS 2017 version of MSBuild - the existing version was not able to build .Net Standard projects. Whether this will cause an issue with your build environment(s) I'm not sure.